### PR TITLE
🐛 Fix login url not linked correctly

### DIFF
--- a/src/fastapi_cloud_cli/commands/login.py
+++ b/src/fastapi_cloud_cli/commands/login.py
@@ -87,7 +87,7 @@ def login() -> Any:
 
             url = authorization_data.verification_uri_complete
 
-            progress.log(f"Opening {url}")
+            progress.log(f"Opening [link={url}]{url}[/link]")
 
         toolkit.print_line()
 


### PR DESCRIPTION
When having a small terminal width, the url would be going to two lines,
and then it would be impossible to CTRL+click it and get the correct
link.
