### PR TITLE
♻️ Rename `app_slug` parameter of `_get_app` to `app_id`

### DIFF
--- a/src/fastapi_cloud_cli/commands/deploy.py
+++ b/src/fastapi_cloud_cli/commands/deploy.py
@@ -263,8 +263,8 @@ def _upload_deployment(
     logger.debug("Upload notification sent successfully")
 
 
-def _get_app(client: APIClient, app_slug: str) -> AppResponse | None:
-    response = client.get(f"/apps/{app_slug}")
+def _get_app(client: APIClient, app_id: str) -> AppResponse | None:
+    response = client.get(f"/apps/{app_id}")
 
     if response.status_code == 404:
         return None
@@ -793,7 +793,7 @@ def deploy(
             with toolkit.progress("Checking app...", transient=True) as progress:
                 with client.handle_http_errors(progress):
                     logger.debug("Checking app with ID: %s", target_app_id)
-                    app = _get_app(client=client, app_slug=target_app_id)
+                    app = _get_app(client=client, app_id=target_app_id)
 
                 if not app:
                     logger.debug("App not found in API")


### PR DESCRIPTION
The parameter of `_get_app` is wrongly named as `app_slug`. The endpoint actually accepts `app_id` as path parameter. And the actual value passed to `_get_app` is app ID, not slug:

https://github.com/fastapilabs/fastapi-cloud-cli/blob/c4be63569d1be808372def5db58cc761ba10a592/src/fastapi_cloud_cli/commands/deploy.py#L796