### PR TITLE
👷 Update `guard-dependencies.yml` workflow to allow modifying dependencies for non-fork PRs

### DIFF
--- a/.github/workflows/guard-dependencies.yml
+++ b/.github/workflows/guard-dependencies.yml
@@ -24,11 +24,16 @@ jobs:
             const author = pr.user.login;
             const assoc = pr.author_association;
 
+            // Is PR branch in the same repo (not a fork)?
+            const sameRepo =
+              pr.head.repo != null && pr.head.repo.id === pr.base.repo.id;
+
             const botAllowlist = new Set(['dependabot[bot]']);
             const orgAuthorAssociations = new Set(['MEMBER', 'OWNER']);
 
             const allowed =
               botAllowlist.has(author) ||
+              sameRepo ||
               (assoc != null && orgAuthorAssociations.has(assoc));
 
             if (!allowed) {
@@ -48,5 +53,5 @@ jobs:
 
               core.setFailed('Dependency changes are restricted to organization members.');
             } else {
-              console.log(`Author ${author} (author_association=${assoc}) is allowed to make dependency changes.`);
+              console.log(`Author ${author} (author_association=${assoc}, sameRepo=${sameRepo}) is allowed to make dependency changes.`);
             }

--- a/.github/workflows/guard-dependencies.yml
+++ b/.github/workflows/guard-dependencies.yml
@@ -22,21 +22,12 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const author = pr.user.login;
-            const assoc = pr.author_association;
 
             // Is PR branch in the same repo (not a fork)?
             const sameRepo =
               pr.head.repo != null && pr.head.repo.id === pr.base.repo.id;
 
-            const botAllowlist = new Set(['dependabot[bot]']);
-            const orgAuthorAssociations = new Set(['MEMBER', 'OWNER']);
-
-            const allowed =
-              botAllowlist.has(author) ||
-              sameRepo ||
-              (assoc != null && orgAuthorAssociations.has(assoc));
-
-            if (!allowed) {
+            if (!sameRepo) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -53,5 +44,5 @@ jobs:
 
               core.setFailed('Dependency changes are restricted to organization members.');
             } else {
-              console.log(`Author ${author} (author_association=${assoc}, sameRepo=${sameRepo}) is allowed to make dependency changes.`);
+              console.log(`Author ${author} (sameRepo=${sameRepo}) is allowed to make dependency changes.`);
             }


### PR DESCRIPTION
Currently `guard-dependencies.yml` closes PRs that modify dependencies even if PR branch is in the same repo (author has write permissions in the repo).

See https://github.com/fastapilabs/fastapi-cloud-cli/pull/208

I suggest we modify it to make decision by checking if the PR branch is in the same repo