### PR TITLE
♻️ Do not suggest `src` as a directory that could contain a `pyproject.toml`

### DIFF
--- a/src/fastapi_cloud_cli/commands/deploy.py
+++ b/src/fastapi_cloud_cli/commands/deploy.py
@@ -396,9 +396,7 @@ def _configure_app(
     initial_directory = selected_app.directory if selected_app else ""
 
     directory_input = toolkit.input(
-        title=(
-            "Directory where your app's pyproject.toml file lives (e.g. backend):"
-        ),
+        title=("Directory where your app's pyproject.toml file lives (e.g. backend):"),
         tag="dir",
         value=initial_directory or "",
         placeholder=(

--- a/src/fastapi_cloud_cli/commands/deploy.py
+++ b/src/fastapi_cloud_cli/commands/deploy.py
@@ -397,7 +397,7 @@ def _configure_app(
 
     directory_input = toolkit.input(
         title=(
-            "Directory where your app's pyproject.toml file lives (e.g. src, backend):"
+            "Directory where your app's pyproject.toml file lives (e.g. backend):"
         ),
         tag="dir",
         value=initial_directory or "",


### PR DESCRIPTION
♻️ Do not suggest `src` as a directory that could contain a `pyproject.toml`

As there's a convention sometimes used for an src-layout, where the `pyproject.toml` refers to an `src` directory with the source code, instead of the `src` directory containing a `pyproject.toml`, I think suggesting it as one of the options to write there could be confusing, I think it's better to only suggest `backend`.