### PR TITLE
🐛 Show a proper error when running on CI and auth is missing

### DIFF
--- a/src/fastapi_cloud_cli/commands/deploy/command.py
+++ b/src/fastapi_cloud_cli/commands/deploy/command.py
@@ -17,6 +17,7 @@ from fastapi_cloud_cli.utils.api import APIClient
 from fastapi_cloud_cli.utils.apps import get_app_config
 from fastapi_cloud_cli.utils.auth import Identity
 from fastapi_cloud_cli.utils.cli import get_rich_toolkit
+from fastapi_cloud_cli.utils.execution import is_ci_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +71,16 @@ def deploy(
     with get_rich_toolkit() as toolkit:
         if not has_auth:
             logger.debug("User not logged in, prompting for login or waitlist")
+
+            if is_ci_enabled():
+                toolkit.fail(
+                    "not_logged_in",
+                    "FASTAPI_CLOUD_TOKEN is required to deploy from CI.",
+                    hint=(
+                        "Run `fastapi cloud setup-ci` to configure a deploy token, "
+                        "or set FASTAPI_CLOUD_TOKEN in your CI secrets."
+                    ),
+                )
 
             toolkit.print_title("Welcome to FastAPI Cloud!", tag="FastAPI")
             toolkit.print_line()

--- a/src/fastapi_cloud_cli/utils/execution.py
+++ b/src/fastapi_cloud_cli/utils/execution.py
@@ -1,3 +1,4 @@
+import os
 from typing import Annotated
 
 import typer
@@ -10,3 +11,12 @@ JsonOutputOption = Annotated[
         help="Print structured JSON to stdout.",
     ),
 ]
+
+
+def is_ci_enabled() -> bool:
+    value = os.environ.get("CI")
+
+    if value is None:
+        return False
+
+    return value.lower() not in {"", "0", "false", "no", "off"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ from .utils import create_jwt_token
 @pytest.fixture(autouse=True)
 def unset_env_vars(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
     """Fixture to unset environment variables that might interfere with tests."""
+    monkeypatch.delenv("CI", raising=False)
     monkeypatch.delenv("FASTAPI_CLOUD_TOKEN", raising=False)
     monkeypatch.setenv("FASTAPI_CLOUD_DISABLE_VERSION_CHECK", "1")
     yield

--- a/tests/test_cli_deploy.py
+++ b/tests/test_cli_deploy.py
@@ -253,6 +253,19 @@ def test_shows_login_prompt_when_token_is_expired(
     assert "What would you like to do?" in result.output
 
 
+def test_fails_with_clear_error_when_running_on_ci_without_token(
+    logged_out_cli: None, tmp_path: Path
+) -> None:
+    with changing_dir(tmp_path):
+        result = runner.invoke(app, ["deploy"], env={"CI": "true"})
+
+    assert result.exit_code == 1
+    assert result.exception is not None
+    assert not isinstance(result.exception, OSError)
+    assert "FASTAPI_CLOUD_TOKEN is required to deploy from CI." in result.output
+    assert "fastapi cloud setup-ci" in result.output
+
+
 @pytest.mark.respx
 def test_shows_error_when_trying_to_get_teams(
     logged_in_cli: None, tmp_path: Path, respx_mock: respx.MockRouter


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack

- #220 (`2026-06-05-add-get-app-command`)
- #219 (`2026-06-03-add-app-list-command`)
- #218 (`2026-06-03-add-get-team-command`)
- #217 (`2026-06-03-add-teams-list-command`)
- #216 (`2026-06-03-improve-how-we-show-the-update-message`)
- **#215** (`2026-06-03-show-a-proper-error-when-running-on-ci-and-auth-is`) <-- this PR
- #214 (merged) (`2026-06-03-refactor-deploy-command-into-multiple-files`)
- #213 (merged) (`2026-06-02-add-support-for-json-for-whoami-and-deploy-command`)
<!-- shortcake:end -->