### PR TITLE
🩹 Fix cloud unlink JSON output and path scope

### DIFF
--- a/src/fastapi_cloud_cli/commands/apps/unlink.py
+++ b/src/fastapi_cloud_cli/commands/apps/unlink.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class UnlinkOutput(BaseModel):
     unlinked: bool
-    path: Path
+    path: Annotated[Path, Field(exclude=True)]
     removed_path: Path
     path_provided: Annotated[bool, Field(exclude=True)] = False
 

--- a/tests/test_cli_unlink.py
+++ b/tests/test_cli_unlink.py
@@ -41,11 +41,15 @@ def test_unlink_compatibility_shortcut_removes_cloud_json(tmp_path: Path) -> Non
     cloud_json = config_dir / "cloud.json"
     cloud_json.write_text('{"app_id": "123", "team_id": "456"}')
 
+    readme_file = config_dir / "README.md"
+    readme_file.write_text("# FastAPI Cloud Configuration")
+
     result = runner.invoke(app, ["unlink", "--path", str(tmp_path)])
 
     assert result.exit_code == 0
     assert "Removed app link" in result.output
     assert not cloud_json.exists()
+    assert readme_file.exists()
     assert config_dir.exists()
 
 
@@ -62,13 +66,37 @@ def test_apps_unlink_as_json(tmp_path: Path) -> None:
     assert json.loads(result.stdout) == {
         "data": {
             "unlinked": True,
-            "path": str(tmp_path),
             "removed_path": str(cloud_json),
         }
     }
     assert result.stderr == ""
     assert config_dir.exists()
     assert not cloud_json.exists()
+
+
+def test_unlink_compatibility_shortcut_as_json(tmp_path: Path) -> None:
+    config_dir = tmp_path / ".fastapicloud"
+    config_dir.mkdir(parents=True)
+
+    cloud_json = config_dir / "cloud.json"
+    cloud_json.write_text('{"app_id": "123", "team_id": "456"}')
+
+    readme_file = config_dir / "README.md"
+    readme_file.write_text("# FastAPI Cloud Configuration")
+
+    result = runner.invoke(app, ["unlink", "--path", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {
+        "data": {
+            "unlinked": True,
+            "removed_path": str(cloud_json),
+        }
+    }
+    assert result.stderr == ""
+    assert config_dir.exists()
+    assert not cloud_json.exists()
+    assert readme_file.exists()
 
 
 def test_apps_unlink_json_returns_not_linked_when_config_is_missing(


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack

- **#239** (`2026-06-11-fix-cloud-unlink-json-output-and-path-scope`) <-- this PR
<!-- shortcake:end -->