### PR TITLE
feat: add get app name in pyproject.toml

### DIFF
--- a/src/fastapi_cloud_cli/commands/deploy/archive.py
+++ b/src/fastapi_cloud_cli/commands/deploy/archive.py
@@ -9,8 +9,10 @@ from pydantic import AfterValidator
 
 logger = logging.getLogger(__name__)
 import sys
+
 if sys.version_info >= (3, 11):
-    import tomllib
+    import tomllib  # type: ignore[import-not-found]
+
 
 def validate_app_directory(v: str | None) -> str | None:
     if v is None:
@@ -44,6 +46,7 @@ def validate_app_directory(v: str | None) -> str | None:
 
 AppDirectory = Annotated[str | None, AfterValidator(validate_app_directory)]
 
+
 def _project_name_from_pyproject(path: Path) -> str:
     if sys.version_info < (3, 11):
         return ""
@@ -67,6 +70,7 @@ def _project_name_from_pyproject(path: Path) -> str:
         return ""
 
     return ""
+
 
 def _get_app_name(path: Path) -> str:
     pyproject_path = path / "pyproject.toml"

--- a/src/fastapi_cloud_cli/commands/deploy/archive.py
+++ b/src/fastapi_cloud_cli/commands/deploy/archive.py
@@ -8,7 +8,9 @@ import rignore
 from pydantic import AfterValidator
 
 logger = logging.getLogger(__name__)
-
+import sys
+if sys.version_info >= (3, 11):
+    import tomllib
 
 def validate_app_directory(v: str | None) -> str | None:
     if v is None:
@@ -42,9 +44,35 @@ def validate_app_directory(v: str | None) -> str | None:
 
 AppDirectory = Annotated[str | None, AfterValidator(validate_app_directory)]
 
+def _project_name_from_pyproject(path: Path) -> str:
+    if sys.version_info < (3, 11):
+        return ""
+
+    if not path.exists():
+        return ""
+
+    try:
+        with path.open("rb") as f:
+            data = tomllib.load(f)
+
+        project_name = data.get("project", {}).get("name")
+        if project_name:
+            return str(project_name)
+
+        poetry_name = data.get("tool", {}).get("poetry", {}).get("name")
+        if poetry_name:
+            return str(poetry_name)
+
+    except Exception:
+        return ""
+
+    return ""
 
 def _get_app_name(path: Path) -> str:
-    # TODO: use pyproject.toml to get the app name
+    pyproject_path = path / "pyproject.toml"
+    name = _project_name_from_pyproject(pyproject_path)
+    if name:
+        return name
     return path.name
 
 

--- a/src/fastapi_cloud_cli/commands/deploy/archive.py
+++ b/src/fastapi_cloud_cli/commands/deploy/archive.py
@@ -1,3 +1,4 @@
+import importlib
 import logging
 import re
 from pathlib import Path, PurePosixPath
@@ -8,10 +9,6 @@ import rignore
 from pydantic import AfterValidator
 
 logger = logging.getLogger(__name__)
-import sys
-
-if sys.version_info >= (3, 11):
-    import tomllib  # type: ignore[import-not-found]
 
 
 def validate_app_directory(v: str | None) -> str | None:
@@ -48,7 +45,12 @@ AppDirectory = Annotated[str | None, AfterValidator(validate_app_directory)]
 
 
 def _project_name_from_pyproject(path: Path) -> str:
-    if sys.version_info < (3, 11):
+    try:
+        tomllib = importlib.import_module("tomllib")
+    except ImportError:
+        return ""
+
+    if tomllib is None:
         return ""
 
     if not path.exists():

--- a/src/fastapi_cloud_cli/commands/deploy/archive.py
+++ b/src/fastapi_cloud_cli/commands/deploy/archive.py
@@ -50,9 +50,6 @@ def _project_name_from_pyproject(path: Path) -> str:
     except ImportError:
         return ""
 
-    if tomllib is None:
-        return ""
-
     if not path.exists():
         return ""
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,9 +1,10 @@
+import sys
 from pathlib import Path
 
 import fastar
 import pytest
 
-from fastapi_cloud_cli.commands.deploy.archive import archive
+from fastapi_cloud_cli.commands.deploy.archive import _get_app_name, archive
 
 
 @pytest.fixture
@@ -163,3 +164,28 @@ def test_archive_includes_hidden_files_but_excludes_env(
         dst_path / ".config",
         dst_path / ".config" / "settings.json",
     }
+
+
+def test_get_app_name_uses_directory_name_when_pyproject_is_missing(
+    tmp_path: Path,
+) -> None:
+    assert _get_app_name(tmp_path) == tmp_path.name
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="tomllib is only available on Python 3.11+",
+)
+def test_get_app_name_uses_project_name_from_pyproject(
+    tmp_path: Path,
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+name = "my-app"
+""",
+        encoding="utf-8",
+    )
+
+    assert _get_app_name(tmp_path) == "my-app"

--- a/tests/test_cli_deploy.py
+++ b/tests/test_cli_deploy.py
@@ -4,6 +4,7 @@ import re
 import string
 from datetime import timedelta
 from pathlib import Path
+import sys
 from typing import TypedDict
 from unittest.mock import patch
 
@@ -20,6 +21,7 @@ from typer.testing import CliRunner
 from fastapi_cloud_cli.cli import app
 from fastapi_cloud_cli.config import Settings
 from fastapi_cloud_cli.utils.api import StreamLogError, TooManyRetriesError
+from fastapi_cloud_cli.commands.deploy.archive import _project_name_from_pyproject
 from tests.conftest import ConfiguredApp
 from tests.utils import Keys, build_logs_response, changing_dir, create_jwt_token
 
@@ -2494,3 +2496,86 @@ def test_invalid_large_file_threshold(
 
     assert result.exit_code == 2
     assert "Invalid value for '--large-file-threshold'" in result.output
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="tomllib is only available on Python 3.11+",
+)
+def test_project_name_from_pyproject_project_section(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+name = "my-app"
+""",
+        encoding="utf-8",
+    )
+
+    result = _project_name_from_pyproject(pyproject)
+
+    assert result == "my-app"
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="tomllib is only available on Python 3.11+",
+)
+def test_project_name_from_pyproject_poetry_section(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[tool.poetry]
+name = "my-poetry-app"
+""",
+        encoding="utf-8",
+    )
+
+    result = _project_name_from_pyproject(pyproject)
+
+    assert result == "my-poetry-app"
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="tomllib is only available on Python 3.11+",
+)
+def test_project_name_from_pyproject_missing_file(tmp_path: Path) -> None:
+    pyproject = tmp_path / "missing.toml"
+
+    result = _project_name_from_pyproject(pyproject)
+
+    assert result == ""
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="tomllib is only available on Python 3.11+",
+)
+def test_project_name_from_pyproject_missing_name(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+version = "0.1.0"
+""",
+        encoding="utf-8",
+    )
+
+    result = _project_name_from_pyproject(pyproject)
+
+    assert result == ""
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="tomllib is only available on Python 3.11+",
+)
+def test_project_name_from_pyproject_invalid_toml(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project
+name = "invalid"
+""",
+        encoding="utf-8",
+    )
+
+    result = _project_name_from_pyproject(pyproject)
+
+    assert result == ""

--- a/tests/test_cli_deploy.py
+++ b/tests/test_cli_deploy.py
@@ -2,9 +2,9 @@ import json
 import random
 import re
 import string
+import sys
 from datetime import timedelta
 from pathlib import Path
-import sys
 from typing import TypedDict
 from unittest.mock import patch
 
@@ -19,9 +19,9 @@ from time_machine import TimeMachineFixture
 from typer.testing import CliRunner
 
 from fastapi_cloud_cli.cli import app
+from fastapi_cloud_cli.commands.deploy.archive import _project_name_from_pyproject
 from fastapi_cloud_cli.config import Settings
 from fastapi_cloud_cli.utils.api import StreamLogError, TooManyRetriesError
-from fastapi_cloud_cli.commands.deploy.archive import _project_name_from_pyproject
 from tests.conftest import ConfiguredApp
 from tests.utils import Keys, build_logs_response, changing_dir, create_jwt_token
 

--- a/tests/test_cli_deploy.py
+++ b/tests/test_cli_deploy.py
@@ -2497,6 +2497,7 @@ def test_invalid_large_file_threshold(
     assert result.exit_code == 2
     assert "Invalid value for '--large-file-threshold'" in result.output
 
+
 @pytest.mark.skipif(
     sys.version_info < (3, 11),
     reason="tomllib is only available on Python 3.11+",
@@ -2514,6 +2515,7 @@ name = "my-app"
     result = _project_name_from_pyproject(pyproject)
 
     assert result == "my-app"
+
 
 @pytest.mark.skipif(
     sys.version_info < (3, 11),
@@ -2533,6 +2535,7 @@ name = "my-poetry-app"
 
     assert result == "my-poetry-app"
 
+
 @pytest.mark.skipif(
     sys.version_info < (3, 11),
     reason="tomllib is only available on Python 3.11+",
@@ -2543,6 +2546,7 @@ def test_project_name_from_pyproject_missing_file(tmp_path: Path) -> None:
     result = _project_name_from_pyproject(pyproject)
 
     assert result == ""
+
 
 @pytest.mark.skipif(
     sys.version_info < (3, 11),
@@ -2561,6 +2565,7 @@ version = "0.1.0"
     result = _project_name_from_pyproject(pyproject)
 
     assert result == ""
+
 
 @pytest.mark.skipif(
     sys.version_info < (3, 11),


### PR DESCRIPTION
This change addresses the existing TODO:

```python
# TODO: use pyproject.toml to get the app name
```

The app name is now resolved from `pyproject.toml` when available, which makes the CLI behavior more consistent with modern Python project metadata and reduces reliance on directory naming conventions.

The previous behavior is preserved as a fallback to maintain compatibility with projects that do not define package metadata.
