### PR TITLE
✨ Add --json support for logout command

### DIFF
--- a/src/fastapi_cloud_cli/commands/logout.py
+++ b/src/fastapi_cloud_cli/commands/logout.py
@@ -1,15 +1,30 @@
+from typing import Any
+
+from pydantic import BaseModel
+from rich_toolkit import RichToolkit
+
 from fastapi_cloud_cli.utils.auth import delete_auth_config
 from fastapi_cloud_cli.utils.cli import get_rich_toolkit
+from fastapi_cloud_cli.utils.execution import JsonOutputOption
 
 
-def logout() -> None:
+class LogoutOutput(BaseModel):
+    logged_out: bool
+
+
+def _render_logout_output(data: LogoutOutput, toolkit: RichToolkit) -> None:
+    toolkit.print_title("FastAPI Cloud")
+    toolkit.print_line()
+    toolkit.print("You are now logged out!", emoji="👋")
+
+
+def logout(json_output: JsonOutputOption = False) -> Any:
     """
     Logout from FastAPI Cloud.
     """
-    with get_rich_toolkit() as toolkit:
-        toolkit.print_title("FastAPI Cloud")
-        toolkit.print_line()
-
+    with get_rich_toolkit(json_output=json_output) as toolkit:
         delete_auth_config()
-
-        toolkit.print("You are now logged out!", emoji="👋")
+        toolkit.success(
+            LogoutOutput(logged_out=True),
+            render_output=_render_logout_output,
+        )

--- a/tests/test_cli_logout.py
+++ b/tests/test_cli_logout.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -28,4 +29,26 @@ def test_logout_with_no_auth_file(temp_auth_config: Path) -> None:
     assert result.exit_code == 0
     assert "You are now logged out!" in result.output
 
+    assert not temp_auth_config.exists()
+
+
+def test_logout_json_with_existing_auth_file(temp_auth_config: Path) -> None:
+    temp_auth_config.write_text('{"access_token": "test_token"}')
+
+    result = runner.invoke(app, ["logout", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {"data": {"logged_out": True}}
+    assert result.stderr == ""
+    assert not temp_auth_config.exists()
+
+
+def test_logout_json_with_no_auth_file(temp_auth_config: Path) -> None:
+    assert not temp_auth_config.exists()
+
+    result = runner.invoke(app, ["logout", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {"data": {"logged_out": True}}
+    assert result.stderr == ""
     assert not temp_auth_config.exists()


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack [🍰](https://shortcake.patrick.wtf)

- #270 (`2026-06-23-add-test-to-make-sure-all-commands-support-json`)
- **#269** (`2026-06-23-add-json-support-for-logout-command`) <-- this PR
- #268 (merged) (`2026-06-23-add-cloud-ci-setup-command`)
- #267 (merged) (`2026-06-23-add-cloud-ci-print-workflow-command`)
<!-- shortcake:end -->