### PR TITLE
👷 Simplify pull request workflow triggers

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,10 +2,6 @@ name: pre-commit
 
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-
 permissions: {}
 
 env:

--- a/.github/workflows/test-redistribute.yml
+++ b/.github/workflows/test-redistribute.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    types:
-      - opened
-      - synchronize
-
 permissions: {}
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    types:
-      - opened
-      - synchronize
   schedule:
     # cron every week on monday
     - cron: "0 0 * * 1"


### PR DESCRIPTION
## Summary
- Simplify workflow `pull_request` event declarations by removing explicit `opened` and `synchronize` activity filters.
- Let GitHub use the default `pull_request` activity set, which also includes `reopened`.

## Validation
- Parsed each changed workflow as YAML before and after the edit.
- Checked the resulting diff is limited to the `pull_request` trigger simplification.

## AI Disclaimer
Using Codex with GPT-5.5. Reviewed manually.
