### PR TITLE
♻️ Remove `src` from `directory` option description and error message

### DIFF
--- a/src/fastapi_cloud_cli/commands/apps/create.py
+++ b/src/fastapi_cloud_cli/commands/apps/create.py
@@ -77,7 +77,7 @@ def create_app(
             "--directory",
             help=(
                 "Relative app directory containing the pyproject.toml "
-                "(for example: src or backend)."
+                "(for example: backend or webserver)."
             ),
         ),
     ] = None,
@@ -156,7 +156,7 @@ def create_app(
                     "invalid_input",
                     f"Invalid app directory: {e}",
                     hint=(
-                        "Pass a relative app directory such as `src` or `backend`; "
+                        "Pass a relative app directory such as `backend` or `webserver`; "
                         "use --path with --link to choose a local filesystem path."
                     ),
                 )

--- a/tests/test_cli_apps.py
+++ b/tests/test_cli_apps.py
@@ -344,7 +344,7 @@ def test_creates_app_json_rejects_invalid_directory(logged_in_cli: None) -> None
             "code": "invalid_input",
             "message": ("Invalid app directory: must be a relative path, not absolute"),
             "hint": (
-                "Pass a relative app directory such as `src` or `backend`; "
+                "Pass a relative app directory such as `backend` or `webserver`; "
                 "use --path with --link to choose a local filesystem path."
             ),
         }


### PR DESCRIPTION
PR https://github.com/fastapilabs/fastapi-cloud-cli/pull/211 removed `src` from the description of `path` option of `fastapi deploy` command.

Removed it from the description of `directory` option for consistency.
